### PR TITLE
Use Open Street Map

### DIFF
--- a/organizations/templates/facility.html
+++ b/organizations/templates/facility.html
@@ -26,7 +26,7 @@
     {% if facility.address_line %}
         <p>
             {{ facility.address_line }}
-            <a target="_blank" href="{{ facility.google_maps_link }}">→ Google
+            <a target="_blank" href="{{ facility.osm_link }}">→ Google
                 Maps</a>
         </p>
     {% endif %}

--- a/organizations/templates/partials/compact_facility.html
+++ b/organizations/templates/partials/compact_facility.html
@@ -1,4 +1,4 @@
-{% load i18n google_links %}
+{% load i18n osm_links %}
 
 <div class="row">
     <div class="col-md-8">
@@ -7,7 +7,7 @@
         {% if facility.address %}
             <p>
                 {{ facility.address_line }}
-                <a target="_blank" href="{{ facility.address_line|google_maps_directions }}">→ Google Maps</a>
+                <a target="_blank" href="{{ facility.address_line|osm_search }}">→ Show on map</a>
             </p>
         {% endif %}
 

--- a/organizations/views.py
+++ b/organizations/views.py
@@ -15,7 +15,7 @@ from django.views.generic import DetailView
 from django_ajax.decorators import ajax
 
 from accounts.models import UserAccount
-from google_tools.templatetags.google_links import google_maps_directions
+from osm_tools.templatetags.osm_links import osm_search
 from news.models import NewsEntry
 from organizations.admin import filter_queryset_by_membership
 from scheduler.models import Shift
@@ -145,8 +145,7 @@ def get_facility_details(facility, shifts):
         'news': _serialize_news(NewsEntry.objects.filter(facility=facility)),
         'address_line': address_line,
         'contact_info': facility.contact_info,
-        'google_maps_link': google_maps_directions(
-            address_line) if address_line else None,
+        'osm_link': osm_search(address_line) if address_line else None,
         'description': mark_safe(facility.description),
         'area_slug': facility.place.area.slug,
         'shifts': [{

--- a/osm_tools/__init__.py
+++ b/osm_tools/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/osm_tools/templatetags/__init__.py
+++ b/osm_tools/templatetags/__init__.py
@@ -1,0 +1,1 @@
+# coding: utf-8

--- a/osm_tools/templatetags/osm_links.py
+++ b/osm_tools/templatetags/osm_links.py
@@ -1,0 +1,18 @@
+# coding: utf-8
+
+from django import template
+from django.utils.translation import pgettext_lazy
+
+register = template.Library()
+
+
+def url_encoded_location(location):
+    return u'+'.join(u'{}'.format(location).split(u' '))
+
+
+@register.filter
+def osm_search(location):
+    location = url_encoded_location(location)
+    pattern = pgettext_lazy('maps search url pattern',
+                            u'https://www.openstreetmap.org/search?query={location}')
+    return pattern.format(location=location)

--- a/scheduler/templates/geographic_helpdesk.html
+++ b/scheduler/templates/geographic_helpdesk.html
@@ -1,6 +1,6 @@
 {% extends "helpdesk_base.html" %}
 
-{% load i18n vpfilters google_links %}
+{% load i18n vpfilters osm_links %}
 
 {% block helpdesk_content %}
 
@@ -64,9 +64,9 @@
                                                 <h3>{{ facility.name }}</h3>
                                                 {% if facility.address %}
                                                     <h5>{{ facility.address_line }}
-                                                        <a href="{{ facility.address_line|google_maps_directions }}"
+                                                        <a href="{{ facility.address_line|osm_search }}"
                                                            target="_blank">
-                                                            &rarr; {% trans "Show on Google Maps" %}
+                                                            &rarr; {% trans "Show on map" %}
                                                         </a>
                                                     </h5>
                                                 {% endif %}

--- a/scheduler/templates/helpdesk.html
+++ b/scheduler/templates/helpdesk.html
@@ -32,7 +32,7 @@
 
 {% endblock %}
 
-{% load google_links i18n %}
+{% load osm_links i18n %}
 {% block content %}
 
         <div ng-cloak class="area-filter row" ng-controller="ShiftWidgetCtrl">
@@ -63,7 +63,7 @@
                                         <div class="col-md-8">
                                             <h5>
                                                 {{ facility.address_line }}
-                                                <a target="_blank" ng-href="{{ facility.google_maps_link }}">→ Google Maps</a>
+                                                <a target="_blank" ng-href="{{ facility.osm_link }}">→ Show on map</a>
                                             </h5>
                                             <p ng-bind-html="facility.description"></p>
                                             <a ng-href="{{ facility.url }}">{% endverbatim %}{% trans "Show details" %}{% verbatim %}</a>

--- a/volunteer_planner/settings/base.py
+++ b/volunteer_planner/settings/base.py
@@ -54,6 +54,7 @@ THIRD_PARTY_APPS = (
 LOCAL_APPS = (
     'api',
     'google_tools',
+    'osm_tools',
     'accounts.apps.AccountsConfig',
     'organizations',
     'common',


### PR DESCRIPTION
Instead of pointing to google maps, point to OSM. Due to the way OSM
works, the user is required to click on the result that best matches the
query - OSM doesn't do that, unlike Google Maps.
